### PR TITLE
PYMT-1379: Set creation date for response based on exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor
 .idea
 composer.lock
+.php_cs.cache
 .phpunit.result.cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /vendor
 .idea
 composer.lock
-*.cache
+.phpunit.result.cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 .idea
 composer.lock
+*.cache

--- a/src/Bridge/Doctrine/Persisters/WebhookPersister.php
+++ b/src/Bridge/Doctrine/Persisters/WebhookPersister.php
@@ -90,6 +90,8 @@ final class WebhookPersister implements WebhookPersisterInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @throws \EoneoPay\Utils\Exceptions\InvalidDateTimeStringException
      */
     public function saveResponseException(
         WebhookRequestInterface $webhookRequest,
@@ -118,6 +120,7 @@ final class WebhookPersister implements WebhookPersisterInterface
             );
         }
 
+        $webhookResponse->setCreatedAt(new DateTime());
         $webhookResponse->setSuccessful(false);
         $webhookResponse->setErrorReason($exception->getMessage());
 

--- a/tests/Unit/Bridge/Doctrine/Persisters/WebhookPersisterTest.php
+++ b/tests/Unit/Bridge/Doctrine/Persisters/WebhookPersisterTest.php
@@ -116,9 +116,12 @@ class WebhookPersisterTest extends TestCase
      * Tests saveResponseException.
      *
      * @return void
+     *
+     * @throws \EoneoPay\Utils\Exceptions\InvalidDateTimeStringException
      */
     public function testSaveResponseNetworkException(): void
     {
+        $now = new DateTime();
         $exception = new NetworkException(new Request(), new Exception('Message'));
 
         $request = new RequestStub(null);
@@ -136,12 +139,15 @@ class WebhookPersisterTest extends TestCase
         self::assertContains($webhookResponse, $saved);
         self::assertFalse($webhookResponse->isSuccessful());
         self::assertSame('Message', $webhookResponse->getData()['errorReason']);
+        self::assertEqualsWithDelta($now, $webhookResponse->getCreatedAt(), 10);
     }
 
     /**
      * Tests saveResponseException.
      *
      * @return void
+     *
+     * @throws \EoneoPay\Utils\Exceptions\InvalidDateTimeStringException
      */
     public function testSaveResponseRequestExceptionNoResponse(): void
     {
@@ -168,6 +174,8 @@ class WebhookPersisterTest extends TestCase
      * Tests saveResponseException.
      *
      * @return void
+     *
+     * @throws \EoneoPay\Utils\Exceptions\InvalidDateTimeStringException
      */
     public function testSaveResponseRequestExceptionWithResponse(): void
     {


### PR DESCRIPTION
In the webhooks library, the `saveResponseException` method in the `WebhookPersister` class was not setting the `createdAt` property value, causing the value to remain as `null` when the entity was persisted.

In this PR, this has been updated to set a creation date, and the `WebhookPersisterTest` has also been updated to check the value.

*Related ticket:* https://eonx.atlassian.net/browse/PYMT-1379
*Related issue:* https://github.com/loyaltycorp/webhooks/issues/35