### PR TITLE
PYMT-1432 Webhook search fillables

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,3 +9,7 @@ parameters:
         -
             message: '#EoneoPay\\Webhooks\\Bridge\\Doctrine\\Entities\\([A-Z][\w]+\\)?[A-Z][\w]+::__construct\(\) does not call parent constructor from EoneoPay\\Externals\\ORM\\Entity\.#'
             path: src/Bridge/Doctrine/Entities
+
+        -
+            message: '#Parameter \#1 \$it of function iterator_to_array expects Traversable, iterable<EoneoPay\\Webhooks\\Bridge\\Doctrine\\Entities\\Entity> given.#'
+            path: tests/Unit/Bridge/Doctrine/Repositories

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,7 @@
 includes:
     - vendor/phpstan/phpstan-strict-rules/rules.neon
     - vendor/phpstan/phpstan-phpunit/extension.neon
+    - vendor/phpstan/phpstan-phpunit/rules.neon
 parameters:
     ignoreErrors:
         -
@@ -9,7 +10,3 @@ parameters:
         -
             message: '#EoneoPay\\Webhooks\\Bridge\\Doctrine\\Entities\\([A-Z][\w]+\\)?[A-Z][\w]+::__construct\(\) does not call parent constructor from EoneoPay\\Externals\\ORM\\Entity\.#'
             path: src/Bridge/Doctrine/Entities
-
-        -
-            message: '#Parameter \#1 \$it of function iterator_to_array expects Traversable, iterable<EoneoPay\\Webhooks\\Bridge\\Doctrine\\Entities\\Entity> given.#'
-            path: tests/Unit/Bridge/Doctrine/Repositories

--- a/src/Bridge/Doctrine/Entities/Lifecycle/Response.php
+++ b/src/Bridge/Doctrine/Entities/Lifecycle/Response.php
@@ -13,7 +13,7 @@ use EoneoPay\Webhooks\Models\WebhookResponseInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
- * @ORM\Entity()
+ * @ORM\Entity(repositoryClass="\EoneoPay\Webhooks\Bridge\Doctrine\Repositories\Lifecycle\ResponseRepository")
  * @ORM\Table(
  *     name="event_activity_responses",
  *     indexes={

--- a/src/Bridge/Doctrine/Repositories/FillableRepository.php
+++ b/src/Bridge/Doctrine/Repositories/FillableRepository.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace EoneoPay\Webhooks\Bridge\Doctrine\Repositories;
+
+use EoneoPay\Externals\ORM\Repository;
+use EoneoPay\Webhooks\Bridge\Doctrine\Repositories\Interfaces\FillableRepositoryInterface;
+
+class FillableRepository extends Repository implements FillableRepositoryInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Doctrine\ORM\ORMException
+     */
+    public function getFillIterable(): iterable
+    {
+        $builder = $this->createQueryBuilder('w');
+
+        foreach ($builder->getQuery()->iterate() as $result) {
+            yield $result[0];
+        }
+    }
+}

--- a/src/Bridge/Doctrine/Repositories/FillableRepository.php
+++ b/src/Bridge/Doctrine/Repositories/FillableRepository.php
@@ -6,7 +6,7 @@ namespace EoneoPay\Webhooks\Bridge\Doctrine\Repositories;
 use EoneoPay\Externals\ORM\Repository;
 use EoneoPay\Webhooks\Bridge\Doctrine\Repositories\Interfaces\FillableRepositoryInterface;
 
-class FillableRepository extends Repository implements FillableRepositoryInterface
+abstract class FillableRepository extends Repository implements FillableRepositoryInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Bridge/Doctrine/Repositories/Interfaces/FillableRepositoryInterface.php
+++ b/src/Bridge/Doctrine/Repositories/Interfaces/FillableRepositoryInterface.php
@@ -9,7 +9,7 @@ interface FillableRepositoryInterface
      * Returns an iterable that is used to fill search indicies with the entity
      * that the repository belongs to.
      *
-     * @return \EoneoPay\Webhooks\Bridge\Doctrine\Entities\Entity[]|\Traversable
+     * @return \EoneoPay\Webhooks\Bridge\Doctrine\Entities\Entity[]
      */
     public function getFillIterable(): iterable;
 }

--- a/src/Bridge/Doctrine/Repositories/Interfaces/FillableRepositoryInterface.php
+++ b/src/Bridge/Doctrine/Repositories/Interfaces/FillableRepositoryInterface.php
@@ -9,7 +9,7 @@ interface FillableRepositoryInterface
      * Returns an iterable that is used to fill search indicies with the entity
      * that the repository belongs to.
      *
-     * @return \EoneoPay\Webhooks\Bridge\Doctrine\Entities\Entity[]
+     * @return \EoneoPay\Webhooks\Bridge\Doctrine\Entities\Entity[]|\Iterator
      */
     public function getFillIterable(): iterable;
 }

--- a/src/Bridge/Doctrine/Repositories/Interfaces/FillableRepositoryInterface.php
+++ b/src/Bridge/Doctrine/Repositories/Interfaces/FillableRepositoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace EoneoPay\Webhooks\Bridge\Doctrine\Repositories\Interfaces;
+
+interface FillableRepositoryInterface
+{
+    /**
+     * Returns an iterable that is used to fill search indicies with the entity
+     * that the repository belongs to.
+     *
+     * @return \EoneoPay\Webhooks\Bridge\Doctrine\Entities\Entity[]|\Traversable
+     */
+    public function getFillIterable(): iterable;
+}

--- a/src/Bridge/Doctrine/Repositories/Interfaces/FillableRepositoryInterface.php
+++ b/src/Bridge/Doctrine/Repositories/Interfaces/FillableRepositoryInterface.php
@@ -9,7 +9,7 @@ interface FillableRepositoryInterface
      * Returns an iterable that is used to fill search indicies with the entity
      * that the repository belongs to.
      *
-     * @return \EoneoPay\Webhooks\Bridge\Doctrine\Entities\Entity[]|\Iterator
+     * @return \EoneoPay\Webhooks\Bridge\Doctrine\Entities\Entity[]
      */
     public function getFillIterable(): iterable;
 }

--- a/src/Bridge/Doctrine/Repositories/Interfaces/WebhookRequestRepositoryInterface.php
+++ b/src/Bridge/Doctrine/Repositories/Interfaces/WebhookRequestRepositoryInterface.php
@@ -6,7 +6,7 @@ namespace EoneoPay\Webhooks\Bridge\Doctrine\Repositories\Interfaces;
 use DateTime;
 use EoneoPay\Webhooks\Models\ActivityInterface;
 
-interface WebhookRequestRepositoryInterface extends FillableRepositoryInterface
+interface WebhookRequestRepositoryInterface
 {
     /**
      * Get list of webhook requests that have failed since provided date time.

--- a/src/Bridge/Doctrine/Repositories/Interfaces/WebhookRequestRepositoryInterface.php
+++ b/src/Bridge/Doctrine/Repositories/Interfaces/WebhookRequestRepositoryInterface.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 namespace EoneoPay\Webhooks\Bridge\Doctrine\Repositories\Interfaces;
 
 use DateTime;
+use EoneoPay\Externals\ORM\Interfaces\RepositoryInterface;
 use EoneoPay\Webhooks\Models\ActivityInterface;
 
-interface WebhookRequestRepositoryInterface
+interface WebhookRequestRepositoryInterface extends RepositoryInterface
 {
     /**
      * Get list of webhook requests that have failed since provided date time.

--- a/src/Bridge/Doctrine/Repositories/Interfaces/WebhookRequestRepositoryInterface.php
+++ b/src/Bridge/Doctrine/Repositories/Interfaces/WebhookRequestRepositoryInterface.php
@@ -6,7 +6,7 @@ namespace EoneoPay\Webhooks\Bridge\Doctrine\Repositories\Interfaces;
 use DateTime;
 use EoneoPay\Webhooks\Models\ActivityInterface;
 
-interface WebhookRequestRepositoryInterface
+interface WebhookRequestRepositoryInterface extends FillableRepositoryInterface
 {
     /**
      * Get list of webhook requests that have failed since provided date time.

--- a/src/Bridge/Doctrine/Repositories/Interfaces/WebhookResponseRepositoryInterface.php
+++ b/src/Bridge/Doctrine/Repositories/Interfaces/WebhookResponseRepositoryInterface.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace EoneoPay\Webhooks\Bridge\Doctrine\Repositories\Interfaces;
+
+interface WebhookResponseRepositoryInterface
+{
+}

--- a/src/Bridge/Doctrine/Repositories/Interfaces/WebhookResponseRepositoryInterface.php
+++ b/src/Bridge/Doctrine/Repositories/Interfaces/WebhookResponseRepositoryInterface.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace EoneoPay\Webhooks\Bridge\Doctrine\Repositories\Interfaces;
 
-interface WebhookResponseRepositoryInterface
+use EoneoPay\Externals\ORM\Interfaces\RepositoryInterface;
+
+interface WebhookResponseRepositoryInterface extends RepositoryInterface
 {
 }

--- a/src/Bridge/Doctrine/Repositories/Lifecycle/RequestRepository.php
+++ b/src/Bridge/Doctrine/Repositories/Lifecycle/RequestRepository.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 namespace EoneoPay\Webhooks\Bridge\Doctrine\Repositories\Lifecycle;
 
 use DateTime;
-use EoneoPay\Externals\ORM\Repository;
+use EoneoPay\Webhooks\Bridge\Doctrine\Repositories\FillableRepository;
 use EoneoPay\Webhooks\Bridge\Doctrine\Repositories\Interfaces\WebhookRequestRepositoryInterface;
 use EoneoPay\Webhooks\Models\ActivityInterface;
 use EoneoPay\Webhooks\Models\WebhookRequestInterface;
 use EoneoPay\Webhooks\Models\WebhookResponseInterface;
 
-class RequestRepository extends Repository implements WebhookRequestRepositoryInterface
+class RequestRepository extends FillableRepository implements WebhookRequestRepositoryInterface
 {
     /**
      * {@inheritdoc}
@@ -51,20 +51,6 @@ class RequestRepository extends Repository implements WebhookRequestRepositoryIn
              * ]
              */
             yield $request[$key];
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @throws \Doctrine\ORM\ORMException
-     */
-    public function getFillIterable(): iterable
-    {
-        $builder = $this->createQueryBuilder('q');
-
-        foreach ($builder->getQuery()->iterate() as $result) {
-            yield $result[0];
         }
     }
 

--- a/src/Bridge/Doctrine/Repositories/Lifecycle/RequestRepository.php
+++ b/src/Bridge/Doctrine/Repositories/Lifecycle/RequestRepository.php
@@ -10,7 +10,7 @@ use EoneoPay\Webhooks\Models\ActivityInterface;
 use EoneoPay\Webhooks\Models\WebhookRequestInterface;
 use EoneoPay\Webhooks\Models\WebhookResponseInterface;
 
-class RequestRepository extends FillableRepository implements WebhookRequestRepositoryInterface
+final class RequestRepository extends FillableRepository implements WebhookRequestRepositoryInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Bridge/Doctrine/Repositories/Lifecycle/RequestRepository.php
+++ b/src/Bridge/Doctrine/Repositories/Lifecycle/RequestRepository.php
@@ -57,6 +57,20 @@ class RequestRepository extends Repository implements WebhookRequestRepositoryIn
     /**
      * {@inheritdoc}
      *
+     * @throws \Doctrine\ORM\ORMException
+     */
+    public function getFillIterable(): iterable
+    {
+        $builder = $this->createQueryBuilder('q');
+
+        foreach ($builder->getQuery()->iterate() as $result) {
+            yield $result[0];
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @throws \Doctrine\ORM\NonUniqueResultException
      */
     public function getLatestActivity(string $primaryClass, string $primaryId): ?ActivityInterface

--- a/src/Bridge/Doctrine/Repositories/Lifecycle/ResponseRepository.php
+++ b/src/Bridge/Doctrine/Repositories/Lifecycle/ResponseRepository.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace EoneoPay\Webhooks\Bridge\Doctrine\Repositories\Lifecycle;
+
+use EoneoPay\Webhooks\Bridge\Doctrine\Repositories\FillableRepository;
+use EoneoPay\Webhooks\Bridge\Doctrine\Repositories\Interfaces\WebhookResponseRepositoryInterface;
+
+class ResponseRepository extends FillableRepository implements WebhookResponseRepositoryInterface
+{
+}

--- a/src/Bridge/Doctrine/Repositories/Lifecycle/ResponseRepository.php
+++ b/src/Bridge/Doctrine/Repositories/Lifecycle/ResponseRepository.php
@@ -6,6 +6,6 @@ namespace EoneoPay\Webhooks\Bridge\Doctrine\Repositories\Lifecycle;
 use EoneoPay\Webhooks\Bridge\Doctrine\Repositories\FillableRepository;
 use EoneoPay\Webhooks\Bridge\Doctrine\Repositories\Interfaces\WebhookResponseRepositoryInterface;
 
-class ResponseRepository extends FillableRepository implements WebhookResponseRepositoryInterface
+final class ResponseRepository extends FillableRepository implements WebhookResponseRepositoryInterface
 {
 }

--- a/tests/Stubs/Bridge/Doctrine/Repositories/FillableRespositoryStub.php
+++ b/tests/Stubs/Bridge/Doctrine/Repositories/FillableRespositoryStub.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\EoneoPay\Webhooks\Stubs\Bridge\Doctrine\Repositories;
+
+use ArrayIterator;
+use EoneoPay\Webhooks\Bridge\Doctrine\Repositories\Interfaces\FillableRepositoryInterface;
+use Tests\EoneoPay\Webhooks\Stubs\Vendor\Doctrine\ORM\RepositoryStub;
+
+/**
+ * @coversNothing
+ */
+class FillableRespositoryStub extends RepositoryStub implements FillableRepositoryInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getFillIterable(): iterable
+    {
+        return new ArrayIterator($this->findAll());
+    }
+}

--- a/tests/Stubs/Bridge/Doctrine/Repositories/Lifecycle/RequestRepositoryStub.php
+++ b/tests/Stubs/Bridge/Doctrine/Repositories/Lifecycle/RequestRepositoryStub.php
@@ -7,12 +7,12 @@ use ArrayIterator;
 use DateTime;
 use EoneoPay\Webhooks\Bridge\Doctrine\Repositories\Interfaces\WebhookRequestRepositoryInterface;
 use EoneoPay\Webhooks\Models\ActivityInterface;
-use Tests\EoneoPay\Webhooks\Stubs\Vendor\Doctrine\ORM\RepositoryStub;
+use Tests\EoneoPay\Webhooks\Stubs\Bridge\Doctrine\Repositories\FillableRespositoryStub;
 
 /**
  * @coversNothing
  */
-class RequestRepositoryStub extends RepositoryStub implements WebhookRequestRepositoryInterface
+class RequestRepositoryStub extends FillableRespositoryStub implements WebhookRequestRepositoryInterface
 {
     /**
      * Activity from latest webhook request.
@@ -80,13 +80,5 @@ class RequestRepositoryStub extends RepositoryStub implements WebhookRequestRepo
     public function getSince(): DateTime
     {
         return $this->since;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getFillIterable(): iterable
-    {
-        return new ArrayIterator($this->findAll());
     }
 }

--- a/tests/Stubs/Bridge/Doctrine/Repositories/Lifecycle/RequestRepositoryStub.php
+++ b/tests/Stubs/Bridge/Doctrine/Repositories/Lifecycle/RequestRepositoryStub.php
@@ -81,4 +81,12 @@ class RequestRepositoryStub extends RepositoryStub implements WebhookRequestRepo
     {
         return $this->since;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFillIterable(): iterable
+    {
+        return new ArrayIterator($this->findAll());
+    }
 }

--- a/tests/Stubs/Bridge/Doctrine/Repositories/Lifecycle/ResponseRepositoryStub.php
+++ b/tests/Stubs/Bridge/Doctrine/Repositories/Lifecycle/ResponseRepositoryStub.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\EoneoPay\Webhooks\Stubs\Bridge\Doctrine\Repositories\Lifecycle;
+
+use Tests\EoneoPay\Webhooks\Stubs\Bridge\Doctrine\Repositories\FillableRespositoryStub;
+
+/**
+ * @coversNothing
+ */
+class ResponseRepositoryStub extends FillableRespositoryStub
+{
+}

--- a/tests/Unit/Bridge/Doctrine/Repositories/DataProvider/WebhookRequestData.php
+++ b/tests/Unit/Bridge/Doctrine/Repositories/DataProvider/WebhookRequestData.php
@@ -112,4 +112,14 @@ class WebhookRequestData
 
         return $this;
     }
+
+    /**
+     * Get requests created.
+     *
+     * @return \EoneoPay\Webhooks\Models\WebhookRequestInterface[]|null
+     */
+    public function getRequests(): ?array
+    {
+        return $this->requests;
+    }
 }

--- a/tests/Unit/Bridge/Doctrine/Repositories/DataProvider/WebhookRequestData.php
+++ b/tests/Unit/Bridge/Doctrine/Repositories/DataProvider/WebhookRequestData.php
@@ -38,6 +38,11 @@ class WebhookRequestData
     private $requests;
 
     /**
+     * @var \EoneoPay\Webhooks\Models\WebhookResponseInterface[]|null
+     */
+    private $responses;
+
+    /**
      * WebhookRequestData constructor.
      *
      * @param \Doctrine\ORM\EntityManagerInterface $entityManager
@@ -47,6 +52,8 @@ class WebhookRequestData
     {
         $this->entityManager = $entityManager;
         $this->activity = $activity;
+        $this->requests = [];
+        $this->responses = [];
     }
 
     /**
@@ -110,6 +117,8 @@ class WebhookRequestData
 
         $this->entityManager->persist($entity);
 
+        $this->responses[$requestId] = $entity;
+
         return $this;
     }
 
@@ -121,5 +130,15 @@ class WebhookRequestData
     public function getRequests(): ?array
     {
         return $this->requests;
+    }
+
+    /**
+     * Get responses created.
+     *
+     * @return \EoneoPay\Webhooks\Models\WebhookResponseInterface[]|null
+     */
+    public function getResponses(): ?array
+    {
+        return $this->responses;
     }
 }

--- a/tests/Unit/Bridge/Doctrine/Repositories/Lifecycle/RequestRepositoryTest.php
+++ b/tests/Unit/Bridge/Doctrine/Repositories/Lifecycle/RequestRepositoryTest.php
@@ -152,7 +152,6 @@ class RequestRepositoryTest extends DoctrineTestCase
         $repository = $this->getRepository();
 
         $iterable = $repository->getFillIterable();
-        /** @noinspection PhpParamsInspection Phpstorm is wrong. iterator is acceptable. */
         $requests = \iterator_to_array($iterable);
 
         self::assertCount(3, $requests);

--- a/tests/Unit/Bridge/Doctrine/Repositories/Lifecycle/RequestRepositoryTest.php
+++ b/tests/Unit/Bridge/Doctrine/Repositories/Lifecycle/RequestRepositoryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Tests\EoneoPay\Webhooks\Unit\Bridge\Doctrine\Repositories\Lifecycle;
 
 use EoneoPay\Utils\DateTime;
-use EoneoPay\Webhooks\Bridge\Doctrine\Repositories\Interfaces\WebhookRequestRepositoryInterface;
+use EoneoPay\Webhooks\Bridge\Doctrine\Repositories\Lifecycle\RequestRepository;
 use EoneoPay\Webhooks\Models\WebhookRequestInterface;
 use Tests\EoneoPay\Webhooks\DoctrineTestCase;
 use Tests\EoneoPay\Webhooks\Stubs\Externals\EntityStub;
@@ -12,6 +12,7 @@ use Tests\EoneoPay\Webhooks\TestCases\Traits\ModelFactoryTrait;
 use Tests\EoneoPay\Webhooks\Unit\Bridge\Doctrine\Repositories\DataProvider\WebhookRequestData;
 
 /**
+ * @covers \EoneoPay\Webhooks\Bridge\Doctrine\Repositories\FillableRepository
  * @covers \EoneoPay\Webhooks\Bridge\Doctrine\Repositories\Lifecycle\RequestRepository
  */
 class RequestRepositoryTest extends DoctrineTestCase
@@ -133,6 +134,7 @@ class RequestRepositoryTest extends DoctrineTestCase
      *
      * @return void
      *
+     * @throws \Doctrine\ORM\ORMException
      * @throws \EoneoPay\Utils\Exceptions\InvalidDateTimeStringException
      * @throws \ReflectionException
      */
@@ -165,6 +167,7 @@ class RequestRepositoryTest extends DoctrineTestCase
      *
      * @return void
      *
+     * @throws \Doctrine\ORM\ORMException
      * @throws \EoneoPay\Utils\Exceptions\InvalidDateTimeStringException
      * @throws \ReflectionException
      */
@@ -215,6 +218,8 @@ class RequestRepositoryTest extends DoctrineTestCase
      * @return void
      *
      * @runInSeparateProcess
+     *
+     * @throws \Doctrine\ORM\NonUniqueResultException
      */
     public function testGetLatestActivityReturnsNull(): void
     {
@@ -228,12 +233,12 @@ class RequestRepositoryTest extends DoctrineTestCase
     /**
      * Get repository.
      *
-     * @return \EoneoPay\Webhooks\Bridge\Doctrine\Repositories\Interfaces\WebhookRequestRepositoryInterface
+     * @return \EoneoPay\Webhooks\Bridge\Doctrine\Repositories\Lifecycle\RequestRepository
      */
-    private function getRepository(): WebhookRequestRepositoryInterface
+    private function getRepository(): RequestRepository
     {
         /**
-         * @var \EoneoPay\Webhooks\Bridge\Doctrine\Repositories\Interfaces\WebhookRequestRepositoryInterface $repository
+         * @var \EoneoPay\Webhooks\Bridge\Doctrine\Repositories\Lifecycle\RequestRepository $repository
          */
         $repository = $this->getEntityManager()->getRepository(WebhookRequestInterface::class);
 

--- a/tests/Unit/Bridge/Doctrine/Repositories/Lifecycle/RequestRepositoryTest.php
+++ b/tests/Unit/Bridge/Doctrine/Repositories/Lifecycle/RequestRepositoryTest.php
@@ -129,6 +129,37 @@ class RequestRepositoryTest extends DoctrineTestCase
     }
 
     /**
+     * Tests that getFillIterable returns expected data.
+     *
+     * @return void
+     *
+     * @throws \EoneoPay\Utils\Exceptions\InvalidDateTimeStringException
+     * @throws \ReflectionException
+     */
+    public function testGetFillIterable(): void
+    {
+        $requestData = new WebhookRequestData($this->getEntityManager());
+        $requestData
+            ->createRequest(new DateTime('2019-10-10 12:00:00'), 1)
+            ->createRequest(new DateTime('2019-10-11 12:00:00'), 2)
+            ->createRequest(new DateTime('2019-10-12 12:00:00'), 3)
+            ->build();
+
+        $expectedRequests = $requestData->getRequests();
+
+        $repository = $this->getRepository();
+
+        $iterable = $repository->getFillIterable();
+        /** @noinspection PhpParamsInspection Phpstorm is wrong. iterator is acceptable. */
+        $requests = \iterator_to_array($iterable);
+
+        self::assertCount(3, $requests);
+        self::assertSame($expectedRequests[1], $requests[0]);
+        self::assertSame($expectedRequests[2], $requests[1]);
+        self::assertSame($expectedRequests[3], $requests[2]);
+    }
+
+    /**
      * Test that get latest activity payload for a given primary class and primary id will
      * return expected activity.
      *

--- a/tests/Unit/Bridge/Doctrine/Repositories/Lifecycle/RequestRepositoryTest.php
+++ b/tests/Unit/Bridge/Doctrine/Repositories/Lifecycle/RequestRepositoryTest.php
@@ -10,6 +10,7 @@ use Tests\EoneoPay\Webhooks\DoctrineTestCase;
 use Tests\EoneoPay\Webhooks\Stubs\Externals\EntityStub;
 use Tests\EoneoPay\Webhooks\TestCases\Traits\ModelFactoryTrait;
 use Tests\EoneoPay\Webhooks\Unit\Bridge\Doctrine\Repositories\DataProvider\WebhookRequestData;
+use Traversable;
 
 /**
  * @covers \EoneoPay\Webhooks\Bridge\Doctrine\Repositories\FillableRepository
@@ -152,12 +153,14 @@ class RequestRepositoryTest extends DoctrineTestCase
         $repository = $this->getRepository();
 
         $iterable = $repository->getFillIterable();
-        $requests = \iterator_to_array($iterable);
+        $requests = $iterable instanceof Traversable
+            ? \iterator_to_array($iterable) :
+            $iterable;
 
         self::assertCount(3, $requests);
-        self::assertSame($expectedRequests[1], $requests[0]);
-        self::assertSame($expectedRequests[2], $requests[1]);
-        self::assertSame($expectedRequests[3], $requests[2]);
+        self::assertContains($expectedRequests[1], $requests);
+        self::assertContains($expectedRequests[2], $requests);
+        self::assertContains($expectedRequests[3], $requests);
     }
 
     /**

--- a/tests/Unit/Bridge/Doctrine/Repositories/Lifecycle/ResponseRepositoryTest.php
+++ b/tests/Unit/Bridge/Doctrine/Repositories/Lifecycle/ResponseRepositoryTest.php
@@ -39,7 +39,6 @@ class ResponseRepositoryTest extends DoctrineTestCase
         $repository = $this->getRepository();
 
         $iterable = $repository->getFillIterable();
-        /** @noinspection PhpParamsInspection Phpstorm is wrong. iterator is acceptable. */
         $responses = \iterator_to_array($iterable);
 
         self::assertCount(2, $responses);

--- a/tests/Unit/Bridge/Doctrine/Repositories/Lifecycle/ResponseRepositoryTest.php
+++ b/tests/Unit/Bridge/Doctrine/Repositories/Lifecycle/ResponseRepositoryTest.php
@@ -3,12 +3,12 @@ declare(strict_types=1);
 
 namespace Tests\EoneoPay\Webhooks\Unit\Bridge\Doctrine\Repositories\Lifecycle;
 
-use ArrayIterator;
 use EoneoPay\Utils\DateTime;
 use EoneoPay\Webhooks\Bridge\Doctrine\Repositories\Interfaces\WebhookResponseRepositoryInterface;
 use EoneoPay\Webhooks\Models\WebhookResponseInterface;
 use Tests\EoneoPay\Webhooks\DoctrineTestCase;
 use Tests\EoneoPay\Webhooks\Unit\Bridge\Doctrine\Repositories\DataProvider\WebhookRequestData;
+use Traversable;
 
 /**
  * @covers \EoneoPay\Webhooks\Bridge\Doctrine\Repositories\FillableRepository
@@ -40,11 +40,14 @@ class ResponseRepositoryTest extends DoctrineTestCase
         $repository = $this->getRepository();
 
         $iterable = $repository->getFillIterable();
-        $responses = \iterator_to_array(new ArrayIterator($iterable));
+
+        $responses = $iterable instanceof Traversable
+            ? \iterator_to_array($iterable) :
+            $iterable;
 
         self::assertCount(2, $responses);
-        self::assertSame($expectedResponses[1], $responses[0]);
-        self::assertSame($expectedResponses[2], $responses[1]);
+        self::assertContains($expectedResponses[1], $responses);
+        self::assertContains($expectedResponses[2], $responses);
     }
 
     /**

--- a/tests/Unit/Bridge/Doctrine/Repositories/Lifecycle/ResponseRepositoryTest.php
+++ b/tests/Unit/Bridge/Doctrine/Repositories/Lifecycle/ResponseRepositoryTest.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\EoneoPay\Webhooks\Unit\Bridge\Doctrine\Repositories\Lifecycle;
+
+use EoneoPay\Utils\DateTime;
+use EoneoPay\Webhooks\Bridge\Doctrine\Repositories\Interfaces\WebhookResponseRepositoryInterface;
+use EoneoPay\Webhooks\Models\WebhookResponseInterface;
+use Tests\EoneoPay\Webhooks\DoctrineTestCase;
+use Tests\EoneoPay\Webhooks\Unit\Bridge\Doctrine\Repositories\DataProvider\WebhookRequestData;
+
+/**
+ * @covers \EoneoPay\Webhooks\Bridge\Doctrine\Repositories\FillableRepository
+ * @covers \EoneoPay\Webhooks\Bridge\Doctrine\Repositories\Lifecycle\ResponseRepository
+ */
+class ResponseRepositoryTest extends DoctrineTestCase
+{
+    /**
+     * Tests that getFillIterable returns expected data.
+     *
+     * @return void
+     *
+     * @throws \Doctrine\ORM\ORMException
+     * @throws \EoneoPay\Utils\Exceptions\InvalidDateTimeStringException
+     * @throws \ReflectionException
+     */
+    public function testGetFillIterable(): void
+    {
+        $requestData = new WebhookRequestData($this->getEntityManager());
+        $requestData
+            ->createRequest(new DateTime('2019-10-10 12:00:00'), 1)
+            ->createRequest(new DateTime('2019-10-11 12:00:00'), 2)
+            ->createResponse(1, 200)
+            ->createResponse(2, 200)
+            ->build();
+
+        $expectedResponses = $requestData->getResponses();
+
+        $repository = $this->getRepository();
+
+        $iterable = $repository->getFillIterable();
+        /** @noinspection PhpParamsInspection Phpstorm is wrong. iterator is acceptable. */
+        $responses = \iterator_to_array($iterable);
+
+        self::assertCount(2, $responses);
+        self::assertSame($expectedResponses[1], $responses[0]);
+        self::assertSame($expectedResponses[2], $responses[1]);
+    }
+
+    /**
+     * Get repository.
+     *
+     * @return \EoneoPay\Webhooks\Bridge\Doctrine\Repositories\Lifecycle\ResponseRepository
+     */
+    private function getRepository(): WebhookResponseRepositoryInterface
+    {
+        /**
+         * @var \EoneoPay\Webhooks\Bridge\Doctrine\Repositories\Lifecycle\ResponseRepository $repository
+         */
+        $repository = $this->getEntityManager()->getRepository(WebhookResponseInterface::class);
+
+        return $repository;
+    }
+}

--- a/tests/Unit/Bridge/Doctrine/Repositories/Lifecycle/ResponseRepositoryTest.php
+++ b/tests/Unit/Bridge/Doctrine/Repositories/Lifecycle/ResponseRepositoryTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Tests\EoneoPay\Webhooks\Unit\Bridge\Doctrine\Repositories\Lifecycle;
 
+use ArrayIterator;
 use EoneoPay\Utils\DateTime;
 use EoneoPay\Webhooks\Bridge\Doctrine\Repositories\Interfaces\WebhookResponseRepositoryInterface;
 use EoneoPay\Webhooks\Models\WebhookResponseInterface;
@@ -39,7 +40,7 @@ class ResponseRepositoryTest extends DoctrineTestCase
         $repository = $this->getRepository();
 
         $iterable = $repository->getFillIterable();
-        $responses = \iterator_to_array($iterable);
+        $responses = \iterator_to_array(new ArrayIterator($iterable));
 
         self::assertCount(2, $responses);
         self::assertSame($expectedResponses[1], $responses[0]);


### PR DESCRIPTION
The webhook request and response repositories now extends `FillableRepository` that has  `getFillIterable()` method which returns (request/response) iterable.

Ticket: [https://eonx.atlassian.net/browse/PYMT-1432](https://eonx.atlassian.net/browse/PYMT-1432)